### PR TITLE
UI polish - prevent lyrics overlap

### DIFF
--- a/src/lib/components/LyricsView.svelte
+++ b/src/lib/components/LyricsView.svelte
@@ -67,7 +67,7 @@
     position: fixed;
     right: 0;
     top: 0;
-    bottom: 0;
+    bottom: var(--player-height);
     width: 340px;
     background: var(--bg-surface);
     border-left: 1px solid var(--bg-overlay);
@@ -75,6 +75,7 @@
     flex-direction: column;
     z-index: 100;
     animation: slideIn 200ms ease;
+    transition: bottom 300ms var(--ease-out-expo);
   }
 
   @keyframes slideIn {


### PR DESCRIPTION
# UI Polish: Prevent Lyrics Overlap

This PR adjusts the lyrics panel layout to ensure it does not overlap with the bottom player controls, providing a cleaner and more consistent user interface.

### 🛡️ Isolation Strategy:
- **Strictly Frontend**: ONLY modifies `src/lib/components/LyricsView.svelte`.
- **Zero Core Changes**: Does NOT touch any backend or global state logic.

### Key Changes:

1. **📏 Layout Synchronization**:
   - Updated the `.lyrics-panel` CSS to use `bottom: var(--player-height)`.
   - This ensures the lyrics panel terminates naturally exactly above the player footer.
   - Added a smooth transition for the `bottom` property to handle potential layout shifts gracefully.

2. **🪄 Visual Polish**:
   - The lyrics panel now feels integrated into the application shell without obscuring critical player controls like the progress bar and volume slider.

This is a minor but high-impact visual fix that improves the overall usability of the app.
